### PR TITLE
Replace usage of `new` constraint with delegates

### DIFF
--- a/src/ClrDebug/ComFactory.cs
+++ b/src/ClrDebug/ComFactory.cs
@@ -1,21 +1,38 @@
 using System;
+using System.Linq.Expressions;
+using System.Reflection;
 using ClrDebug.Native;
 
 namespace ClrDebug
 {
     internal static class ComFactory
     {
-        public unsafe static void Create<T>(void* ptr, int hResult, out T value) where T : IComReference, new()
+        private static readonly ConstructorInfo s_missingMethodExceptionCtor;
+
+        static ComFactory()
+        {
+            s_missingMethodExceptionCtor = typeof(MissingMethodException)
+                .GetConstructor(
+                    BindingFlags.Instance | BindingFlags.Public,
+                    binder: null,
+                    types: new[] { typeof(string) },
+                    modifiers: null);
+        }
+
+        public unsafe static void Create<T>(void* ptr, int hResult, out T value)
+            where T : Unknown
         {
             value = Create<T>(ptr, hResult);
         }
 
-        public unsafe static void Create<T>(void* ptr, out T value) where T : IComReference, new()
+        public unsafe static void Create<T>(void* ptr, out T value)
+            where T : Unknown
         {
             value = Create<T>(ptr);
         }
 
-        public unsafe static T Create<T>(void* ptr, int hResult) where T : IComReference, new()
+        public unsafe static T Create<T>(void* ptr, int hResult)
+            where T : Unknown
         {
             if (hResult != HResult.S_OK)
             {
@@ -25,16 +42,62 @@ namespace ClrDebug
             return Create<T>(ptr);
         }
 
-        public unsafe static T Create<T>(void* ptr) where T : IComReference, new()
+        public unsafe static T Create<T>(void* ptr)
+            where T : Unknown
         {
             if (ptr == null)
             {
                 return default;
             }
 
-            var comObject = new T();
+            var comObject = ConstructorCache<T>.Ctor();
             comObject.SetPointer((void**)ptr);
             return comObject;
+        }
+
+        private static class ConstructorCache<TUnknown> where TUnknown : Unknown
+        {
+            public static readonly Func<TUnknown> Ctor;
+
+            static ConstructorCache()
+            {
+                Ctor = CreateConstructor();
+            }
+
+            private static Func<TUnknown> CreateConstructor()
+            {
+                if (typeof(TUnknown).IsAbstract)
+                {
+                    return ThrowMissingMemberException("Cannot create an abstract class.");
+                }
+
+                ConstructorInfo ctor = typeof(TUnknown)
+                    .GetConstructor(
+                        BindingFlags.Instance | BindingFlags.NonPublic,
+                        binder: null,
+                        types: Type.EmptyTypes,
+                        modifiers: null);
+
+                if (ctor == null)
+                {
+                    return ThrowMissingMemberException(
+                        "No parameterless constructor defined for this object.");
+                }
+
+                return Expression.Lambda<Func<TUnknown>>(Expression.New(ctor)).Compile();
+            }
+
+            private static Func<TUnknown> ThrowMissingMemberException(string message)
+            {
+                    return Expression.Lambda<Func<TUnknown>>(
+                        Expression.Throw(
+                            Expression.New(
+                                s_missingMethodExceptionCtor,
+                                Expression.Constant(
+                                    message,
+                                    typeof(string)))))
+                        .Compile();
+            }
         }
     }
 }

--- a/src/ClrDebug/Native/CorDebugEnum.cs
+++ b/src/ClrDebug/Native/CorDebugEnum.cs
@@ -191,20 +191,20 @@ namespace ClrDebug.Native
     /// <summary>
     /// Represents any non-abstract interface that inherits ICorDebugEnum.
     /// </summary>
-    public class CorDebugComEnum<T> : CorDebugEnum<T>, IEnumerable<T>
-        where T : IComReference, new()
+    public class CorDebugComEnum<TUnknown> : CorDebugEnum<TUnknown>, IEnumerable<TUnknown>
+        where TUnknown : Unknown
     {
         /// <inheritdoc />
-        public override unsafe int Clone(out CorDebugEnum<T> ppEnum)
+        public override unsafe int Clone(out CorDebugEnum<TUnknown> ppEnum)
         {
             void** clonedEnum = default;
             int hResult = Calli(_this, This[0]->Clone, &clonedEnum);
-            ppEnum = ComFactory.Create<CorDebugComEnum<T>>(clonedEnum, hResult);
+            ppEnum = ComFactory.Create<CorDebugComEnum<TUnknown>>(clonedEnum, hResult);
             return hResult;
         }
 
         /// <inheritdoc />
-        public override unsafe int Next(Span<T> buffer, out int amountWritten)
+        public override unsafe int Next(Span<TUnknown> buffer, out int amountWritten)
         {
             int count = buffer.Length;
             Span<IntPtr> nativeBuffer = count < 60 ? stackalloc IntPtr[count] : new IntPtr[count];
@@ -216,7 +216,7 @@ namespace ClrDebug.Native
                 amountWritten = unchecked((int)celtFetched);
                 for (int i = 0; i < amountWritten; i++)
                 {
-                    buffer[i] = ComFactory.Create<T>(b[i]);
+                    buffer[i] = ComFactory.Create<TUnknown>(b[i]);
                 }
 
                 return result;
@@ -225,20 +225,20 @@ namespace ClrDebug.Native
 
         public Enumerator GetEnumerator() => new Enumerator(this);
 
-        IEnumerator<T> IEnumerable<T>.GetEnumerator() => GetEnumerator();
+        IEnumerator<TUnknown> IEnumerable<TUnknown>.GetEnumerator() => GetEnumerator();
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public struct Enumerator : IEnumerator<T>
+        public struct Enumerator : IEnumerator<TUnknown>
         {
-            private readonly CorDebugEnum<T> _parent;
+            private readonly CorDebugEnum<TUnknown> _parent;
 
             private readonly bool _ownsParent;
 
             private unsafe void** _ptr;
 
-            internal unsafe Enumerator(CorDebugComEnum<T> parent)
+            internal unsafe Enumerator(CorDebugComEnum<TUnknown> parent)
             {
                 int hResult = parent.Clone(out _parent);
                 _ownsParent = hResult != HResult.E_NOTIMPL;
@@ -254,7 +254,7 @@ namespace ClrDebug.Native
                 _ptr = default;
             }
 
-            public unsafe T Current => ComFactory.Create<T>(_ptr);
+            public unsafe TUnknown Current => ComFactory.Create<TUnknown>(_ptr);
 
             object IEnumerator.Current => Current;
 

--- a/src/ClrDebug/Native/Unknown.cs
+++ b/src/ClrDebug/Native/Unknown.cs
@@ -5,14 +5,13 @@ using static ClrDebug.Native.CalliInstructions;
 
 namespace ClrDebug.Native
 {
-    public partial class Unknown : IUnknown, IComReference, IDisposable
+    public partial class Unknown : IUnknown, IDisposable
     {
         protected unsafe void** _this;
 
         private bool _isDisposed;
 
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public Unknown()
+        private protected Unknown()
         {
         }
 
@@ -21,21 +20,6 @@ namespace ClrDebug.Native
         ~Unknown() => Dispose(false);
 
         public unsafe bool IsDefault => _this == default;
-
-        public unsafe void** DangerousGetPointer()
-        {
-            if (_isDisposed)
-            {
-                throw new ObjectDisposedException(null);
-            }
-
-            if (_this == default)
-            {
-                throw new ArgumentNullException(nameof(_this));
-            }
-
-            return _this;
-        }
 
         public void Dispose()
         {
@@ -50,7 +34,7 @@ namespace ClrDebug.Native
 
         public unsafe int Release() => Calli(_this, This[0]->Release);
 
-        public unsafe bool TryGetInterface<T>(in Guid riid, out T comObject) where T : IComReference, new()
+        public unsafe bool TryGetInterface<T>(in Guid riid, out T comObject) where T : Unknown
         {
             void* ppvObject;
             fixed (Guid* pRiid = &riid)
@@ -67,7 +51,7 @@ namespace ClrDebug.Native
             return true;
         }
 
-        unsafe void IComReference.SetPointer(void** ptr)
+        internal unsafe void SetPointer(void** ptr)
         {
             if (_isDisposed)
             {
@@ -86,6 +70,21 @@ namespace ClrDebug.Native
         internal ComPointer AcquirePointer()
         {
             return new ComPointer(this);
+        }
+
+        internal unsafe void** DangerousGetPointer()
+        {
+            if (_isDisposed)
+            {
+                throw new ObjectDisposedException(null);
+            }
+
+            if (_this == default)
+            {
+                throw new ArgumentNullException(nameof(_this));
+            }
+
+            return _this;
         }
 
         protected unsafe void** AssertNotDisposed(void** ptr)

--- a/src/ClrDebug/NativeArray.cs
+++ b/src/ClrDebug/NativeArray.cs
@@ -5,29 +5,30 @@ namespace ClrDebug.Native
 {
     internal static class NativeArray
     {
-        public static NativeComArray<T> AllocCom<T>(ReadOnlySpan<T> managedArray) where T : IComReference, IUnknown
+        public static NativeComArray<TUnknown> AllocCom<TUnknown>(ReadOnlySpan<TUnknown> managedArray)
+            where TUnknown : Unknown
         {
-            return NativeComArray<T>.Alloc(managedArray);
+            return NativeComArray<TUnknown>.Alloc(managedArray);
         }
     }
 
-    internal readonly unsafe ref struct NativeComArray<T> where T : IComReference, IUnknown
+    internal readonly unsafe ref struct NativeComArray<TUnknown> where TUnknown : Unknown
     {
         public readonly void*** Pointer;
 
-        private readonly ReadOnlySpan<T> _managed;
+        private readonly ReadOnlySpan<TUnknown> _managed;
 
-        private NativeComArray(void*** array, ReadOnlySpan<T> managed)
+        private NativeComArray(void*** array, ReadOnlySpan<TUnknown> managed)
         {
             Pointer = array;
             _managed = managed;
         }
 
-        public static implicit operator void*(NativeComArray<T> nativeArray) => nativeArray.Pointer;
+        public static implicit operator void*(NativeComArray<TUnknown> nativeArray) => nativeArray.Pointer;
 
-        public static explicit operator void**(NativeComArray<T> nativeArray) => (void**)nativeArray.Pointer;
+        public static explicit operator void**(NativeComArray<TUnknown> nativeArray) => (void**)nativeArray.Pointer;
 
-        public static implicit operator void***(NativeComArray<T> nativeArray) => nativeArray.Pointer;
+        public static implicit operator void***(NativeComArray<TUnknown> nativeArray) => nativeArray.Pointer;
 
         public void Dispose()
         {
@@ -43,7 +44,7 @@ namespace ClrDebug.Native
             }
         }
 
-        public static NativeComArray<T> Alloc(ReadOnlySpan<T> managedArray)
+        public static NativeComArray<TUnknown> Alloc(ReadOnlySpan<TUnknown> managedArray)
         {
             if (managedArray.IsEmpty)
             {
@@ -61,7 +62,7 @@ namespace ClrDebug.Native
                     ptr[i] = managedArray[i].DangerousGetPointer();
                 }
 
-                return new NativeComArray<T>(ptr, managedArray);
+                return new NativeComArray<TUnknown>(ptr, managedArray);
             }
             catch
             {

--- a/src/ClrDebug/UnsafeOps.cs
+++ b/src/ClrDebug/UnsafeOps.cs
@@ -1,13 +1,14 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 
+using ClrDebug.Native;
 using static ClrDebug.Native.CalliInstructions;
 
 namespace ClrDebug
 {
-    public static class UnsafeOps
+    internal static class UnsafeOps
     {
-        internal static unsafe ReadOnlySpan<char> WCharToSpan(char* ptr)
+        public static unsafe ReadOnlySpan<char> WCharToSpan(char* ptr)
         {
             if (ptr == default)
             {
@@ -25,11 +26,12 @@ namespace ClrDebug
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static unsafe int InvokeGetObject<T>(void* @this, void* slot, out T value) where T : IComReference, new()
+        public static unsafe int InvokeGetObject<TUnknown>(void* @this, void* slot, out TUnknown value)
+            where TUnknown : Unknown
         {
             void** pValue = default;
             int result = Calli(@this, slot, &pValue);
-            value = ComFactory.Create<T>(pValue, result);
+            value = ComFactory.Create<TUnknown>(pValue, result);
 
             return result;
         }


### PR DESCRIPTION
Use a factory class that generates cached delegates instead of new().

Also make construction and pointer retrieval of com objects internal.